### PR TITLE
set odom_origin orientation to '0'

### DIFF
--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -539,6 +539,8 @@ tf2::Transform Player::getOdomTfAt(unsigned int entry)
     if(!has_odom_origin_)
     {
         odom_origin_ = t;
+        // set origin orientation to 0
+        odom_origin_.setRotation(tf2::Quaternion(0,0,0,1));
         has_odom_origin_ = true;
     }
 


### PR DESCRIPTION
Our position wrt a hypothetic /world is off by the origin orientation.
We should set the beginning position based on the GPS data only, in order to have a correct oxts' TF while integrating another package (in my case the rviz_satellite package)
